### PR TITLE
feat: Add --keep_special_tokens argument to control special token decoding

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -75,6 +75,7 @@ def main(
     temperature: float = 1.0,
     top_k: int = 50,
     top_p: float = 1.0,
+    keep_special_tokens: bool = False,
 ):
 
     os.makedirs(os.path.abspath(os.path.dirname(output_path)), exist_ok=True)
@@ -196,7 +197,7 @@ def main(
                     )
 
                     tgt_text = tokenizer.batch_decode(
-                        generated_tokens, skip_special_tokens=True
+                        generated_tokens, skip_special_tokens=not keep_special_tokens
                     )
                     if accelerator.is_main_process:
                         if (
@@ -335,6 +336,12 @@ if __name__ == "__main__":
         help="If do_sample is True, will sample from the top k most likely tokens.",
     )
 
+    parser.add_argument(
+        "--keep_special_tokens",
+        action="store_true",
+        help="Keep special tokens in the decoded text.",
+    )
+
     args = parser.parse_args()
 
     main(
@@ -353,4 +360,5 @@ if __name__ == "__main__":
         temperature=args.temperature,
         top_k=args.top_k,
         top_p=args.top_p,
+        keep_special_tokens=args.keep_special_tokens
     )


### PR DESCRIPTION
## Description

This PR adds the command line argument `--keep_special_tokens`, thus removing the hardcoded `True` value for `skip_special_tokens` in `tokenizer.batch_decode`.

The reasoning behind this PR is that users should be allowed to use the `<unk>` token as a separator between sentences before translation. This allows users to translate sentence pairs together, instead of separately, thus avoiding a decrease in the lexical overlap between sentence pairs. For more information, refer to the paper ["Translation Artifacts in Cross-lingual Transfer Learning" by Mikel Artetxe, Gorka Labaka, Eneko Agirre](https://arxiv.org/abs/2004.04721).

## Changes Made

- Added `--keep_special_tokens` command line argument.
- Removed hardcoded `True` value for `skip_special_tokens` in `tokenizer.batch_decode`.

## Related Issue

N/A

## Additional Information

N/A
